### PR TITLE
feat: convert SelfFilterNode to rclcpp_lifecycle::LifecycleNode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(yaml-cpp REQUIRED)
 
 # ROS 2 packages
 find_package(rclcpp REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(geometry_msgs REQUIRED)
@@ -170,6 +171,7 @@ ament_target_dependencies(${PROJECT_NAME}
 
 ament_target_dependencies(self_filter
   rclcpp
+  rclcpp_lifecycle
   tf2
   tf2_ros
   geometry_msgs

--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,7 @@
 
   <!-- Build dependencies -->
   <build_depend>rclcpp</build_depend>
+  <build_depend>rclcpp_lifecycle</build_depend>
   <build_depend>tf2</build_depend>
   <build_depend>tf2_ros</build_depend>
   <build_depend>geometry_msgs</build_depend>
@@ -30,6 +31,7 @@
 
   <!-- Execution dependencies -->
   <exec_depend>rclcpp</exec_depend>
+  <exec_depend>rclcpp_lifecycle</exec_depend>
   <exec_depend>tf2</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>

--- a/src/self_filter.cpp
+++ b/src/self_filter.cpp
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include <rclcpp/rclcpp.hpp>
+#include <rclcpp_lifecycle/lifecycle_node.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/create_timer_ros.h>
@@ -33,11 +34,13 @@ namespace robot_self_filter
     PandarSensor = 5,
   };
 
-  class SelfFilterNode : public rclcpp::Node
+  class SelfFilterNode : public rclcpp_lifecycle::LifecycleNode
   {
   public:
+    using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
     SelfFilterNode()
-        : Node("self_filter")
+        : rclcpp_lifecycle::LifecycleNode("self_filter")
     {
       try
       {
@@ -48,14 +51,16 @@ namespace robot_self_filter
       {
       }
 
-      this->declare_parameter<std::string>("sensor_frame", "Lidar"); // Default value
-      // this->set_parameter(rclcpp::Parameter("sensor_frame", "Lidar")); // Removed explicit set
+      this->declare_parameter<std::string>("sensor_frame", "Lidar");
       this->declare_parameter<bool>("use_rgb", false);
       this->declare_parameter<int>("max_queue_size", 10);
       this->declare_parameter<int>("lidar_sensor_type", 0);
       this->declare_parameter<std::string>("robot_description", "");
       this->declare_parameter<std::string>("in_pointcloud_topic", "/cloud_in");
+    }
 
+    CallbackReturn on_configure(const rclcpp_lifecycle::State &)
+    {
       sensor_frame_ = this->get_parameter("sensor_frame").as_string();
       use_rgb_ = this->get_parameter("use_rgb").as_bool();
       max_queue_size_ = this->get_parameter("max_queue_size").as_int();
@@ -63,10 +68,8 @@ namespace robot_self_filter
       sensor_type_ = static_cast<SensorType>(temp_sensor_type);
       in_topic_ = this->get_parameter("in_pointcloud_topic").as_string();
 
-      RCLCPP_INFO(this->get_logger(), "Parameters:");
+      RCLCPP_INFO(this->get_logger(), "Configuring SelfFilterNode:");
       RCLCPP_INFO(this->get_logger(), "  sensor_frame: %s", sensor_frame_.c_str());
-      RCLCPP_INFO(this->get_logger(), "  use_rgb: %s", use_rgb_ ? "true" : "false");
-      RCLCPP_INFO(this->get_logger(), "  max_queue_size: %d", max_queue_size_);
       RCLCPP_INFO(this->get_logger(), "  lidar_sensor_type: %d", temp_sensor_type);
       RCLCPP_INFO(this->get_logger(), "  in_pointcloud_topic: %s", in_topic_.c_str());
 
@@ -77,13 +80,50 @@ namespace robot_self_filter
               this->get_node_timers_interface()));
       tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
 
-      // Publish filtered cloud as sensor data QoS (BEST_EFFORT) for high-rate streams
       pointCloudPublisher_ =
           this->create_publisher<sensor_msgs::msg::PointCloud2>(
               "cloud_out", rclcpp::SensorDataQoS());
 
       marker_pub_ =
           this->create_publisher<visualization_msgs::msg::MarkerArray>("collision_shapes", 1);
+
+      return CallbackReturn::SUCCESS;
+    }
+
+    CallbackReturn on_activate(const rclcpp_lifecycle::State & state)
+    {
+      LifecycleNode::on_activate(state);
+      RCLCPP_INFO(this->get_logger(), "Activating SelfFilterNode — starting point cloud subscription");
+      initSelfFilter();
+      return CallbackReturn::SUCCESS;
+    }
+
+    CallbackReturn on_deactivate(const rclcpp_lifecycle::State & state)
+    {
+      RCLCPP_INFO(this->get_logger(), "Deactivating SelfFilterNode — stopping subscription");
+      sub_.reset();
+      self_filter_.reset();
+      frames_.clear();
+      LifecycleNode::on_deactivate(state);
+      return CallbackReturn::SUCCESS;
+    }
+
+    CallbackReturn on_cleanup(const rclcpp_lifecycle::State &)
+    {
+      tf_listener_.reset();
+      tf_buffer_.reset();
+      pointCloudPublisher_.reset();
+      marker_pub_.reset();
+      return CallbackReturn::SUCCESS;
+    }
+
+    CallbackReturn on_shutdown(const rclcpp_lifecycle::State &)
+    {
+      sub_.reset();
+      self_filter_.reset();
+      tf_listener_.reset();
+      tf_buffer_.reset();
+      return CallbackReturn::SUCCESS;
     }
 
     void initSelfFilter()
@@ -117,7 +157,6 @@ namespace robot_self_filter
 
       self_filter_->getLinkNames(frames_);
 
-      // Subscribe to input cloud with sensor data QoS (BEST_EFFORT)
       rclcpp::QoS input_qos = rclcpp::SensorDataQoS();
       sub_ = this->create_subscription<sensor_msgs::msg::PointCloud2>(
           in_topic_,
@@ -293,8 +332,8 @@ namespace robot_self_filter
     std::shared_ptr<filters::SelfFilterInterface> self_filter_;
 
     rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr sub_;
-    rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pointCloudPublisher_;
-    rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr marker_pub_;
+    rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::PointCloud2>::SharedPtr pointCloudPublisher_;
+    rclcpp_lifecycle::LifecyclePublisher<visualization_msgs::msg::MarkerArray>::SharedPtr marker_pub_;
 
     std::string sensor_frame_;
     bool use_rgb_;
@@ -309,9 +348,10 @@ namespace robot_self_filter
 int main(int argc, char **argv)
 {
   rclcpp::init(argc, argv);
+  rclcpp::executors::SingleThreadedExecutor executor;
   auto node = std::make_shared<robot_self_filter::SelfFilterNode>();
-  node->initSelfFilter();
-  rclcpp::spin(node);
+  executor.add_node(node->get_node_base_interface());
+  executor.spin();
   rclcpp::shutdown();
   return 0;
 }


### PR DESCRIPTION
## Summary

- Converts `SelfFilterNode` from `rclcpp::Node` to `rclcpp_lifecycle::LifecycleNode`
- Splits node logic across lifecycle callbacks:
  - `on_configure`: reads parameters, sets up TF buffer/listener, creates publishers
  - `on_activate`: creates the point cloud subscription and initializes the self-filter
  - `on_deactivate`: destroys subscription and resets filter state to stop processing
  - `on_cleanup` / `on_shutdown`: tears down TF and publishers
- Adds `rclcpp_lifecycle` dependency to `CMakeLists.txt` and `package.xml`

## Motivation

Running the self-filter pipeline continuously is wasteful when the robot is docked or idle. With lifecycle management, an external node (e.g. a mission controller) can activate the filter only when needed — saving significant CPU during idle periods.

## Behaviour changes

- Node must now be transitioned to `active` state before it processes any point clouds. When `inactive`, no subscription exists and no CPU is consumed.
- Publishers are created in `on_configure` so they are available for downstream discovery before activation.
- No changes to filtering logic, QoS, or topic names.

## Test plan

- Verified node transitions correctly through `configure → activate → deactivate → cleanup` via `ros2 lifecycle set`
- Confirmed point clouds are filtered when active and no messages are processed when inactive
- Tested with Ouster LiDAR (sensor type 2) on ROS 2 Humble