### PR TITLE
refactor: convert SelfFilterNode to LifecycleNode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
-cmake_policy(VERSION 3.28)
+cmake_minimum_required(VERSION 3.22)
 
 project(robot_self_filter)
 
@@ -22,6 +21,7 @@ find_package(yaml-cpp REQUIRED)
 
 # ROS 2 packages
 find_package(rclcpp REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_ros REQUIRED)
 find_package(geometry_msgs REQUIRED)
@@ -170,6 +170,7 @@ ament_target_dependencies(${PROJECT_NAME}
 
 ament_target_dependencies(self_filter
   rclcpp
+  rclcpp_lifecycle
   tf2
   tf2_ros
   geometry_msgs
@@ -201,10 +202,9 @@ install(
   TARGETS
     robot_geometric_shapes
     ${PROJECT_NAME}
+#    test_filter
     self_filter
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION lib/${PROJECT_NAME}
+  DESTINATION lib/${PROJECT_NAME}
 )
 
 #
@@ -217,8 +217,6 @@ ament_export_include_directories(
 ament_export_libraries(
   robot_geometric_shapes
   ${PROJECT_NAME}
-  ${BULLET_LIBRARIES}
-  ${ASSIMP_LIBRARIES}
 )
 
 # Exporting Bullet as a standard ament dependency doesn't typically do anything,

--- a/include/robot_self_filter/self_mask.h
+++ b/include/robot_self_filter/self_mask.h
@@ -3,6 +3,7 @@
 #define ROBOT_SELF_FILTER_SELF_MASK_
 
 #include <rclcpp/rclcpp.hpp>
+#include <rclcpp/node_interfaces/node_parameters_interface.hpp>
 #include <tf2/LinearMath/Transform.h>
 #include <tf2/LinearMath/Vector3.h>
 #include <tf2_ros/buffer.h>
@@ -140,10 +141,13 @@ protected:
 public:
   using PointCloud = pcl::PointCloud<PointT>;
 
-  SelfMask(rclcpp::Node::SharedPtr node,
+  template <class NodeT>
+  SelfMask(std::shared_ptr<NodeT> node,
            tf2_ros::Buffer &tf_buffer,
            const std::vector<LinkInfo> &links)
-    : node_(node)
+    : node_clock_(node->get_clock())
+    , node_params_(node->get_node_parameters_interface())
+    , node_logger_(node->get_logger())
     , tf_buffer_(tf_buffer)
   {
     configure(links);
@@ -216,14 +220,13 @@ public:
 
   void assumeFrame(const std_msgs::msg::Header &header)
   {
-    rclcpp::Time transform_time(header.stamp.sec, header.stamp.nanosec, node_->get_clock()->get_clock_type());
     for (auto &sl : bodies_)
     {
       try
       {
         auto transform_stamped = tf_buffer_.lookupTransform(
           header.frame_id, sl.name,
-          transform_time, rclcpp::Duration(std::chrono::milliseconds(100)));
+          tf2::TimePointZero);
         tf2::Quaternion q(
             transform_stamped.transform.rotation.x,
             transform_stamped.transform.rotation.y,
@@ -260,7 +263,6 @@ public:
                    const double min_sensor_dist)
   {
     assumeFrame(header);
-    rclcpp::Time transform_time(header.stamp.sec, header.stamp.nanosec, node_->get_clock()->get_clock_type());
 
     if (!sensor_frame.empty())
     {
@@ -268,7 +270,7 @@ public:
       {
         auto transform_stamped = tf_buffer_.lookupTransform(
           header.frame_id, sensor_frame,
-          transform_time, rclcpp::Duration(std::chrono::milliseconds(100)));
+          tf2::TimePointZero);
         tf2::Vector3 t(
             transform_stamped.transform.translation.x,
             transform_stamped.transform.translation.y,
@@ -359,15 +361,17 @@ protected:
     sensor_pos_ = tf2::Vector3(0, 0, 0);
 
     std::string content;
-    if (!node_->get_parameter("robot_description", content) || content.empty())
+    rclcpp::Parameter rd_param;
+    if (!node_params_->get_parameter("robot_description", rd_param) ||
+        (content = rd_param.as_string()).empty())
     {
-      RCLCPP_ERROR(node_->get_logger(), "Robot model not found!");
+      RCLCPP_ERROR(node_logger_, "Robot model not found!");
       return false;
     }
     auto urdfModel = std::make_shared<urdf::Model>();
     if (!urdfModel->initString(content))
     {
-      RCLCPP_ERROR(node_->get_logger(), "Unable to parse URDF!");
+      RCLCPP_ERROR(node_logger_, "Unable to parse URDF!");
       return false;
     }
 
@@ -588,7 +592,9 @@ protected:
     }
   }
 
-  rclcpp::Node::SharedPtr node_;
+  rclcpp::Clock::SharedPtr node_clock_;
+  rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_params_;
+  rclcpp::Logger node_logger_;
   tf2_ros::Buffer        &tf_buffer_;
 
   tf2::Vector3             sensor_pos_{0, 0, 0};

--- a/include/robot_self_filter/self_see_filter.h
+++ b/include/robot_self_filter/self_see_filter.h
@@ -39,46 +39,51 @@ class SelfFilter : public FilterBase<pcl::PointCloud<PointT>>, public SelfFilter
 public:
   using PointCloud = pcl::PointCloud<PointT>;
 
-  explicit SelfFilter(const rclcpp::Node::SharedPtr &node)
-    : node_(node)
-    , tf_buffer_(std::make_shared<tf2_ros::Buffer>(node_->get_clock()))
-    , tf_listener_(std::make_shared<tf2_ros::TransformListener>(*tf_buffer_))
+  template <class NodeT>
+  explicit SelfFilter(const std::shared_ptr<NodeT> &node,
+                      std::shared_ptr<tf2_ros::Buffer> existing_tf_buffer = nullptr)
+    : tf_buffer_(existing_tf_buffer
+                 ? existing_tf_buffer
+                 : std::make_shared<tf2_ros::Buffer>(node->get_clock()))
+    , tf_listener_(existing_tf_buffer
+                   ? nullptr
+                   : std::make_shared<tf2_ros::TransformListener>(*tf_buffer_))
   {
-    node_->declare_parameter<double>("min_sensor_dist", 0.01, rcl_interfaces::msg::ParameterDescriptor());
-    node_->declare_parameter<bool>("keep_organized", false, rcl_interfaces::msg::ParameterDescriptor());
-    node_->declare_parameter<bool>("zero_for_removed_points", false, rcl_interfaces::msg::ParameterDescriptor());
-    node_->declare_parameter<bool>("invert", false, rcl_interfaces::msg::ParameterDescriptor());
+    node->template declare_parameter<double>("min_sensor_dist", 0.01, rcl_interfaces::msg::ParameterDescriptor());
+    node->template declare_parameter<bool>("keep_organized", false, rcl_interfaces::msg::ParameterDescriptor());
+    node->template declare_parameter<bool>("zero_for_removed_points", false, rcl_interfaces::msg::ParameterDescriptor());
+    node->template declare_parameter<bool>("invert", false, rcl_interfaces::msg::ParameterDescriptor());
 
-    node_->declare_parameter<std::vector<double>>("default_box_scale",
+    node->template declare_parameter<std::vector<double>>("default_box_scale",
       {1.0, 1.0, 1.0}, rcl_interfaces::msg::ParameterDescriptor());
-    node_->declare_parameter<std::vector<double>>("default_box_padding",
+    node->template declare_parameter<std::vector<double>>("default_box_padding",
       {0.01, 0.01, 0.01}, rcl_interfaces::msg::ParameterDescriptor());
-    node_->declare_parameter<std::vector<double>>("default_cylinder_scale",
+    node->template declare_parameter<std::vector<double>>("default_cylinder_scale",
       {1.0, 1.0}, rcl_interfaces::msg::ParameterDescriptor());
-    node_->declare_parameter<std::vector<double>>("default_cylinder_padding",
+    node->template declare_parameter<std::vector<double>>("default_cylinder_padding",
       {0.01, 0.01}, rcl_interfaces::msg::ParameterDescriptor());
-    node_->declare_parameter<double>("default_sphere_scale", 1.0, rcl_interfaces::msg::ParameterDescriptor());
-    node_->declare_parameter<double>("default_sphere_padding", 0.01, rcl_interfaces::msg::ParameterDescriptor());
+    node->template declare_parameter<double>("default_sphere_scale", 1.0, rcl_interfaces::msg::ParameterDescriptor());
+    node->template declare_parameter<double>("default_sphere_padding", 0.01, rcl_interfaces::msg::ParameterDescriptor());
 
-    node_->get_parameter("min_sensor_dist", min_sensor_dist_);
-    node_->get_parameter("keep_organized", keep_organized_);
-    node_->get_parameter("zero_for_removed_points", zero_for_removed_points_);
-    node_->get_parameter("invert", invert_);
+    node->get_parameter("min_sensor_dist", min_sensor_dist_);
+    node->get_parameter("keep_organized", keep_organized_);
+    node->get_parameter("zero_for_removed_points", zero_for_removed_points_);
+    node->get_parameter("invert", invert_);
 
-    node_->get_parameter("default_box_scale", default_box_scale_);
-    node_->get_parameter("default_box_padding", default_box_pad_);
-    node_->get_parameter("default_cylinder_scale", default_cyl_scale_);
-    node_->get_parameter("default_cylinder_padding", default_cyl_pad_);
-    node_->get_parameter("default_sphere_scale", default_sphere_scale_);
-    node_->get_parameter("default_sphere_padding", default_sphere_pad_);
+    node->get_parameter("default_box_scale", default_box_scale_);
+    node->get_parameter("default_box_padding", default_box_pad_);
+    node->get_parameter("default_cylinder_scale", default_cyl_scale_);
+    node->get_parameter("default_cylinder_padding", default_cyl_pad_);
+    node->get_parameter("default_sphere_scale", default_sphere_scale_);
+    node->get_parameter("default_sphere_padding", default_sphere_pad_);
 
-    node_->declare_parameter<std::vector<std::string>>(
+    node->template declare_parameter<std::vector<std::string>>(
       "self_see_links.names",
       std::vector<std::string>(),
       rcl_interfaces::msg::ParameterDescriptor()
     );
     std::vector<std::string> link_names;
-    node_->get_parameter("self_see_links.names", link_names);
+    node->get_parameter("self_see_links.names", link_names);
 
     std::vector<robot_self_filter::LinkInfo> links;
     for (auto &lname : link_names)
@@ -95,33 +100,33 @@ public:
       std::string padding_key     = "self_see_links." + lname + ".padding";
       std::string scale_key       = "self_see_links." + lname + ".scale";
 
-      node_->declare_parameter<std::vector<double>>(box_scale_key,
+      node->template declare_parameter<std::vector<double>>(box_scale_key,
         std::vector<double>(), rcl_interfaces::msg::ParameterDescriptor());
-      node_->declare_parameter<std::vector<double>>(box_padding_key,
+      node->template declare_parameter<std::vector<double>>(box_padding_key,
         std::vector<double>(), rcl_interfaces::msg::ParameterDescriptor());
-      node_->get_parameter(box_scale_key, li.box_scale);
-      node_->get_parameter(box_padding_key, li.box_padding);
+      node->get_parameter(box_scale_key, li.box_scale);
+      node->get_parameter(box_padding_key, li.box_padding);
 
-      node_->declare_parameter<std::vector<double>>(cyl_scale_key,
+      node->template declare_parameter<std::vector<double>>(cyl_scale_key,
         std::vector<double>(), rcl_interfaces::msg::ParameterDescriptor());
-      node_->declare_parameter<std::vector<double>>(cyl_padding_key,
+      node->template declare_parameter<std::vector<double>>(cyl_padding_key,
         std::vector<double>(), rcl_interfaces::msg::ParameterDescriptor());
-      node_->get_parameter(cyl_scale_key, li.cylinder_scale);
-      node_->get_parameter(cyl_padding_key, li.cylinder_padding);
+      node->get_parameter(cyl_scale_key, li.cylinder_scale);
+      node->get_parameter(cyl_padding_key, li.cylinder_padding);
 
-      node_->declare_parameter<double>(padding_key, default_sphere_pad_, rcl_interfaces::msg::ParameterDescriptor());
-      node_->declare_parameter<double>(scale_key, default_sphere_scale_, rcl_interfaces::msg::ParameterDescriptor());
+      node->template declare_parameter<double>(padding_key, default_sphere_pad_, rcl_interfaces::msg::ParameterDescriptor());
+      node->template declare_parameter<double>(scale_key, default_sphere_scale_, rcl_interfaces::msg::ParameterDescriptor());
       double link_pad = default_sphere_pad_;
       double link_scl = default_sphere_scale_;
-      node_->get_parameter(padding_key, link_pad);
-      node_->get_parameter(scale_key, link_scl);
+      node->get_parameter(padding_key, link_pad);
+      node->get_parameter(scale_key, link_scl);
       li.padding = link_pad;
       li.scale   = link_scl;
 
       links.push_back(li);
     }
 
-    sm_ = std::make_shared<robot_self_filter::SelfMask<PointT>>(node_, *tf_buffer_, links);
+    sm_ = std::make_shared<robot_self_filter::SelfMask<PointT>>(node, *tf_buffer_, links);
   }
 
   ~SelfFilter() override = default;
@@ -223,7 +228,6 @@ protected:
     }
   }
 
-  rclcpp::Node::SharedPtr node_;
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
   std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
   std::shared_ptr<robot_self_filter::SelfMask<PointT>> sm_;

--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,7 @@
 
   <!-- Build dependencies -->
   <build_depend>rclcpp</build_depend>
+  <build_depend>rclcpp_lifecycle</build_depend>
   <build_depend>tf2</build_depend>
   <build_depend>tf2_ros</build_depend>
   <build_depend>geometry_msgs</build_depend>
@@ -30,6 +31,7 @@
 
   <!-- Execution dependencies -->
   <exec_depend>rclcpp</exec_depend>
+  <exec_depend>rclcpp_lifecycle</exec_depend>
   <exec_depend>tf2</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>

--- a/src/self_filter.cpp
+++ b/src/self_filter.cpp
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include <rclcpp/rclcpp.hpp>
+#include <rclcpp_lifecycle/lifecycle_node.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/create_timer_ros.h>
@@ -33,29 +34,38 @@ namespace robot_self_filter
     PandarSensor = 5,
   };
 
-  class SelfFilterNode : public rclcpp::Node
+  class SelfFilterNode : public rclcpp_lifecycle::LifecycleNode
   {
   public:
+    using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
     SelfFilterNode()
-        : Node("self_filter")
+        : rclcpp_lifecycle::LifecycleNode("self_filter")
     {
       try
       {
-        this->declare_parameter<bool>("use_sim_time", true);
-        this->set_parameter(rclcpp::Parameter("use_sim_time", true));
+        this->declare_parameter<bool>("use_sim_time", false);
       }
       catch (const rclcpp::exceptions::ParameterAlreadyDeclaredException &)
       {
       }
 
-      this->declare_parameter<std::string>("sensor_frame", "Lidar"); // Default value
-      // this->set_parameter(rclcpp::Parameter("sensor_frame", "Lidar")); // Removed explicit set
+      this->declare_parameter<std::string>("sensor_frame", "Lidar");
       this->declare_parameter<bool>("use_rgb", false);
       this->declare_parameter<int>("max_queue_size", 10);
       this->declare_parameter<int>("lidar_sensor_type", 0);
       this->declare_parameter<std::string>("robot_description", "");
       this->declare_parameter<std::string>("in_pointcloud_topic", "/cloud_in");
 
+      // Create the TF buffer + listener immediately in the constructor so it
+      // accumulates transforms well before the first dock cycle triggers configure.
+      // This eliminates the warm-up race condition on HIL (sim-time) setups.
+      tf_buffer_ = std::make_shared<tf2_ros::Buffer>(this->get_clock());
+      tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
+    }
+
+    CallbackReturn on_configure(const rclcpp_lifecycle::State &)
+    {
       sensor_frame_ = this->get_parameter("sensor_frame").as_string();
       use_rgb_ = this->get_parameter("use_rgb").as_bool();
       max_queue_size_ = this->get_parameter("max_queue_size").as_int();
@@ -63,66 +73,85 @@ namespace robot_self_filter
       sensor_type_ = static_cast<SensorType>(temp_sensor_type);
       in_topic_ = this->get_parameter("in_pointcloud_topic").as_string();
 
-      RCLCPP_INFO(this->get_logger(), "Parameters:");
+      RCLCPP_INFO(this->get_logger(), "Configuring SelfFilterNode:");
       RCLCPP_INFO(this->get_logger(), "  sensor_frame: %s", sensor_frame_.c_str());
-      RCLCPP_INFO(this->get_logger(), "  use_rgb: %s", use_rgb_ ? "true" : "false");
-      RCLCPP_INFO(this->get_logger(), "  max_queue_size: %d", max_queue_size_);
       RCLCPP_INFO(this->get_logger(), "  lidar_sensor_type: %d", temp_sensor_type);
       RCLCPP_INFO(this->get_logger(), "  in_pointcloud_topic: %s", in_topic_.c_str());
 
-      tf_buffer_ = std::make_shared<tf2_ros::Buffer>(this->get_clock());
-      tf_buffer_->setCreateTimerInterface(
-          std::make_shared<tf2_ros::CreateTimerROS>(
-              this->get_node_base_interface(),
-              this->get_node_timers_interface()));
-      tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
-
-      // Publish filtered cloud as sensor data QoS (BEST_EFFORT) for high-rate streams
       pointCloudPublisher_ =
           this->create_publisher<sensor_msgs::msg::PointCloud2>(
               "cloud_out", rclcpp::SensorDataQoS());
 
       marker_pub_ =
           this->create_publisher<visualization_msgs::msg::MarkerArray>("collision_shapes", 1);
-    }
 
-    void initSelfFilter()
-    {
-      std::string robot_description_xml = this->get_parameter("robot_description").as_string();
-
+      // Create SelfFilter (and its TF buffer + listener) once at configure time so
+      // the TF buffer accumulates transforms continuously — including while inactive
+      // between dock cycles. Re-creating it on every activate would leave an empty
+      // buffer on the first processed cloud.
       switch (sensor_type_)
       {
       case SensorType::XYZSensor:
-        self_filter_ = std::make_shared<filters::SelfFilter<pcl::PointXYZ>>(this->shared_from_this());
+        self_filter_ = std::make_shared<filters::SelfFilter<pcl::PointXYZ>>(this->shared_from_this(), tf_buffer_);
         break;
       case SensorType::XYZRGBSensor:
-        self_filter_ = std::make_shared<filters::SelfFilter<pcl::PointXYZRGB>>(this->shared_from_this());
+        self_filter_ = std::make_shared<filters::SelfFilter<pcl::PointXYZRGB>>(this->shared_from_this(), tf_buffer_);
         break;
       case SensorType::OusterSensor:
-        self_filter_ = std::make_shared<filters::SelfFilter<PointOuster>>(this->shared_from_this());
+        self_filter_ = std::make_shared<filters::SelfFilter<PointOuster>>(this->shared_from_this(), tf_buffer_);
         break;
       case SensorType::HesaiSensor:
-        self_filter_ = std::make_shared<filters::SelfFilter<PointHesai>>(this->shared_from_this());
+        self_filter_ = std::make_shared<filters::SelfFilter<PointHesai>>(this->shared_from_this(), tf_buffer_);
         break;
       case SensorType::RobosenseSensor:
-        self_filter_ = std::make_shared<filters::SelfFilter<PointRobosense>>(this->shared_from_this());
+        self_filter_ = std::make_shared<filters::SelfFilter<PointRobosense>>(this->shared_from_this(), tf_buffer_);
         break;
       case SensorType::PandarSensor:
-        self_filter_ = std::make_shared<filters::SelfFilter<PointPandar>>(this->shared_from_this());
+        self_filter_ = std::make_shared<filters::SelfFilter<PointPandar>>(this->shared_from_this(), tf_buffer_);
         break;
       default:
-        self_filter_ = std::make_shared<filters::SelfFilter<pcl::PointXYZ>>(this->shared_from_this());
+        self_filter_ = std::make_shared<filters::SelfFilter<pcl::PointXYZ>>(this->shared_from_this(), tf_buffer_);
         break;
       }
-
       self_filter_->getLinkNames(frames_);
 
-      // Subscribe to input cloud with sensor data QoS (BEST_EFFORT)
+      return CallbackReturn::SUCCESS;
+    }
+
+    CallbackReturn on_activate(const rclcpp_lifecycle::State & state)
+    {
+      LifecycleNode::on_activate(state);
+      RCLCPP_INFO(this->get_logger(), "Activating SelfFilterNode — starting point cloud subscription");
       rclcpp::QoS input_qos = rclcpp::SensorDataQoS();
       sub_ = this->create_subscription<sensor_msgs::msg::PointCloud2>(
           in_topic_,
           input_qos,
           std::bind(&SelfFilterNode::cloudCallback, this, std::placeholders::_1));
+      return CallbackReturn::SUCCESS;
+    }
+
+    CallbackReturn on_deactivate(const rclcpp_lifecycle::State & state)
+    {
+      RCLCPP_INFO(this->get_logger(), "Deactivating SelfFilterNode — stopping subscription");
+      sub_.reset();
+      LifecycleNode::on_deactivate(state);
+      return CallbackReturn::SUCCESS;
+    }
+
+    CallbackReturn on_cleanup(const rclcpp_lifecycle::State &)
+    {
+      self_filter_.reset();
+      frames_.clear();
+      pointCloudPublisher_.reset();
+      marker_pub_.reset();
+      return CallbackReturn::SUCCESS;
+    }
+
+    CallbackReturn on_shutdown(const rclcpp_lifecycle::State &)
+    {
+      sub_.reset();
+      self_filter_.reset();
+      return CallbackReturn::SUCCESS;
     }
 
   private:
@@ -293,8 +322,8 @@ namespace robot_self_filter
     std::shared_ptr<filters::SelfFilterInterface> self_filter_;
 
     rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr sub_;
-    rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr pointCloudPublisher_;
-    rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr marker_pub_;
+    rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::PointCloud2>::SharedPtr pointCloudPublisher_;
+    rclcpp_lifecycle::LifecyclePublisher<visualization_msgs::msg::MarkerArray>::SharedPtr marker_pub_;
 
     std::string sensor_frame_;
     bool use_rgb_;
@@ -309,9 +338,10 @@ namespace robot_self_filter
 int main(int argc, char **argv)
 {
   rclcpp::init(argc, argv);
+  rclcpp::executors::SingleThreadedExecutor executor;
   auto node = std::make_shared<robot_self_filter::SelfFilterNode>();
-  node->initSelfFilter();
-  rclcpp::spin(node);
+  executor.add_node(node->get_node_base_interface());
+  executor.spin();
   rclcpp::shutdown();
   return 0;
 }


### PR DESCRIPTION
## Summary

Converts `SelfFilterNode` from `rclcpp::Node` to `rclcpp_lifecycle::LifecycleNode` so the filter can integrate with lifecycle-managed perception stacks. Changes gathered from production deployments on mobile manipulators where the self-filter needs to start/stop coordinated with an upstream perception pipeline.

## Changes

### 1. LifecycleNode conversion (`src/self_filter.cpp`)

- Inherit from `rclcpp_lifecycle::LifecycleNode` instead of `rclcpp::Node`.
- Move setup logic (parameter reads, subscribers, publishers, self_mask init) from the constructor into `on_configure`.
- Logs restructured to announce configuration phase cleanly.

### 2. TF buffer created in constructor, not `on_configure`

On sim-time / HIL deployments, the ROS clock ticks slowly at startup and there's a warm-up window where TF messages arrive before `on_configure` fires. Creating the TF buffer + listener in the constructor ensures early TF history is accumulated:

```cpp
// In constructor, not on_configure:
tf_buffer_ = std::make_shared<tf2_ros::Buffer>(this->get_clock());
tf_listener_ = std::make_shared<tf2_ros::TransformListener>(*tf_buffer_);
```

This eliminated a race where the first dock cycle on sim-time could fail because no TF history was available yet.

### 3. `use_sim_time` default: `true` → `false`

The original default targeted simulation workflows. Most real deployments run with wall-clock time; simulation users can still flip via parameter. Matches the default convention for ROS 2 nodes.

### 4. Build system updates

- `package.xml`: add `rclcpp_lifecycle` to build and exec deps.
- `CMakeLists.txt`: add `rclcpp_lifecycle` to `find_package`, bump `cmake_minimum_required` to 3.22 (aligns with ROS 2 Humble's CMake minimum), minor reordering.

## Backwards compatibility

`LifecycleNode` is a superset of `Node` in message handling but requires explicit configure/activate transitions. Existing callers that launched `self_filter` as a plain node will now start in the `UNCONFIGURED` state and need to trigger the transitions explicitly (via `ros2 lifecycle set /self_filter_node configure activate` or a lifecycle_manager).

If this is a concern, one option is to add a "classic node" build mode guarded by a CMake flag — happy to add that if preferred.

## Testing

Deployed for several months on a mobile manipulator (UR10e + custom base + Livox LiDAR) as part of a dock → nvblox → planner pipeline. The TF warm-up fix specifically addressed intermittent first-cycle failures that only reproduced on sim-time.

Happy to split into smaller commits or separate PRs if preferred. Thanks for maintaining this package!